### PR TITLE
Add HTTP::Request object to the HTTP::Response

### DIFF
--- a/lib/HTTP/Thin.pm
+++ b/lib/HTTP/Thin.pm
@@ -7,41 +7,50 @@ use warnings;
 use parent qw(HTTP::Tiny);
 use Safe::Isa;
 use Class::Method::Modifiers;
+use HTTP::Request;
 use HTTP::Response;
 use Hash::MultiValue;
 
 
 =method request
 
-In addition to the parameters documented in L<HTTP::Tiny>, C<HTTP::Thin> takes L<HTTP::Request> objects as well. 
+In addition to the parameters documented in L<HTTP::Tiny>, C<HTTP::Thin> takes L<HTTP::Request> objects as well.
 
 The return value is an L<HTTP::Response> object.
 
 =cut
 
 around request => sub {
-        my ($next, $self, @args) = @_;
-        if (@args == 1 && $args[0]->$_isa('HTTP::Request')) {
-                my $req = shift @args;
-                my @headers;
-                $req->headers->scan(sub { push @headers, @_ });
-                        
-                my $options = {};
-                $options->{headers} = Hash::MultiValue->new(@headers)->mixed if @headers;
-                $options->{content} = $req->content if length($req->content);
-                @args = ( 
-                        $req->method,
-                        $req->uri,
-                        ( keys %$options ? $options : () ),
-                );
-        }
-        my $res =  $self->$next(@args);
-        return HTTP::Response->new(
-                $res->{status},
-                $res->{reason},
-                [ Hash::MultiValue->from_mixed($res->{headers})->flatten ],
-                $res->{content},
+    my ($next, $self, @args) = @_;
+    my $req;
+    if (@args == 1 && $args[0]->$_isa('HTTP::Request')) {
+        $req = shift @args;
+        my @headers;
+        $req->headers->scan(sub { push @headers, @_ });
+
+        my $options = {};
+        $options->{headers} = Hash::MultiValue->new(@headers)->mixed if @headers;
+        $options->{content} = $req->content if length($req->content);
+        @args = (
+            $req->method,
+            $req->uri,
+            ( keys %$options ? $options : () ),
         );
+    }
+    else {
+        my ( $method, $uri, %options ) = @args;
+        my $content = delete $options{content} // '';
+        $req = HTTP::Request->new($method, $uri, [ %options], $content);
+    }
+    my $res =  $self->$next(@args);
+    my $http_response = HTTP::Response->new(
+        $res->{status},
+        $res->{reason},
+        [ Hash::MultiValue->from_mixed($res->{headers})->flatten ],
+        $res->{content},
+    );
+    $http_response->request($req);
+    return $http_response;
 };
 
 1;
@@ -64,4 +73,4 @@ C<HTTP::Thin> is a thin wrapper around L<HTTP::Tiny> adding the ability to pass 
 
 =head1 WHY?
 
-A conversation on IRC lead to C<mst>, C<ether>, and I agreeing that this would be a useful module but probably not worth the effort. I wrote it anyway to get it out of my head. 
+A conversation on IRC lead to C<mst>, C<ether>, and I agreeing that this would be a useful module but probably not worth the effort. I wrote it anyway to get it out of my head.


### PR DESCRIPTION
An HTTP response from LWP::UserAgent, for example, includes an HTTP::Request object. This should make HTTP::Thin a better drop-in replacement for use cases where the request is expected.

For some reason, indent appeared to be 8 characters. I changed it to 4. So, it may be helpful to add the `w=1` option on github to see the substantive changes, or `git diff -w` on the command-line.